### PR TITLE
shift cost metric date range back one day to ensure full cost is recieved for end date

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ import { getAvgServerResForDomains } from './metrics/plausible.js';
 const log = (object) => console.log(util.inspect(object, false, null, true));
 
 // Prepare start and end dates
-const endDate = endOfYesterday();
+let endDate = endOfYesterday();
 let startDate = sub(endDate, { days: config.DAYS_BACK });
 startDate = add(startDate, { seconds: 1 });
 const periodString = `${config.DAYS_BACK}d`;
@@ -41,6 +41,9 @@ switch (argv[2]) {
         log(await getGbIATI());
         break;
     case 'cost':
+        // shift cost back an additional day as there is a lag in cost metrics
+        startDate = sub(startDate, { days: 1 });
+        endDate = sub(endDate, { days: 1 });
         log(await getRawCost(startDate, endDate));
         break;
     case 'acu':

--- a/metrics/index.js
+++ b/metrics/index.js
@@ -1,3 +1,4 @@
+import { sub } from 'date-fns';
 import db from '../config/db/database.js';
 import {
     getGbIATI,
@@ -41,7 +42,10 @@ const runMetrics = async (startDate, endDate) => {
         const gibIATI = await getGbIATI();
 
         // Azure Cost
-        const costData = getMetricCost(await getRawCost(startDate, endDate));
+        // shift cost back an additional day as there is a lag in cost metrics availability
+        const costStartDate = sub(startDate, { days: 1 });
+        const costEndDate = sub(endDate, { days: 1 });
+        const costData = getMetricCost(await getRawCost(costStartDate, costEndDate));
 
         cost.startDate = startDate;
         cost.endDate = endDate;


### PR DESCRIPTION
[Trello](https://trello.com/c/WBivgwtH)